### PR TITLE
Add dependency resolution.

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -1,4 +1,5 @@
 import { readFileSync as readFile } from 'fs';
+import path from 'path';
 import readData from 'data-uri-to-buffer';
 import mimeTypes from 'mime-types';
 import fetch from 'make-fetch-happen';
@@ -61,11 +62,51 @@ async function loadURL(url, fetchOpts) {
   }
 }
 
+function isBearSpecifier(specifier) {
+  if (path.extname(specifier) !== '') {
+    return false
+  }
+
+  if (specifier.startsWith('@')) {
+    return specifier.split('/').length === 2
+  }
+
+  return specifier.split('/').length === 1
+}
+
+function packageName(absolutePath) {
+  const segments = absolutePath.split('/')
+  if (absolutePath.startsWith('/@')) {
+    return path.join(segments[1], segments[2])
+  }
+
+  return segments[1]
+}
+
 export default function urlResolve(fetchOpts) {
   return {
-    resolveId(source) {
+    async resolveId(source, importer) {
       const url = parseURL(source);
-      return url ? resolveURL(url) : null;
+      if (url) {
+        return resolveURL(url)
+      }
+
+      const importerUrl = parseURL(importer);
+      if (!importerUrl) {
+        return null
+      }
+
+      if (isBearSpecifier(source)) {
+        const importerPackage = packageName(importerUrl.pathname)
+        importerUrl.pathname = path.join(importerPackage, 'package.json')
+        const packageJson = JSON.parse(await loadURL(importerUrl, fetchOpts))
+        const version = packageJson.dependencies[source]
+        importerUrl.pathname = `${source}@${version}`
+        return importerUrl.toString()
+      }
+
+      importerUrl.pathname = source
+      return importerUrl.toString()
     },
     load(id) {
       const url = parseURL(id);

--- a/modules/index.js
+++ b/modules/index.js
@@ -84,11 +84,11 @@ function packageName(absolutePath) {
   const segments = absolutePath.split('/');
 
   if (absolutePath.startsWith('/@')) {
-    // Output example "@foo/string-length@4.0.1"
+    // Output example: "@foo/string-length@4.0.1"
     return path.join(segments[1], segments[2]);
   }
 
-  // Output example "string-length@4.0.1"
+  // Output example: "string-length@4.0.1"
   return segments[1];
 }
 


### PR DESCRIPTION
By adding this feature, you can import a module containing bare imports like this.

```
import stringLength from 'https://unpkg.com/string-length'
```

Resolution handling is very immature, so there should be many cases it cannot process, but I confirmed I could import the above package at least.

If this feature is not appropriate for this plugin, I'm going to make it a separate plugin.

