### PR TITLE
Match `text/javascript` content type for rewrite

### DIFF
--- a/modules/rewriteRelativeImports.js
+++ b/modules/rewriteRelativeImports.js
@@ -2,6 +2,7 @@ import rewriteRelativeJavaScriptImports from './rewriteRelativeJavaScriptImports
 
 export default function rewriteRelativeImports(base, contentType, code) {
   switch (contentType) {
+    case 'text/javascript':
     case 'application/javascript':
       return rewriteRelativeJavaScriptImports(base, code);
     default:


### PR DESCRIPTION
The latest spec for [HTML](https://html.spec.whatwg.org/multipage/#scriptingLanguages) and [RFC 9239](https://www.rfc-editor.org/rfc/rfc9239) calls for using `text/javascript` over other content types.

My motivation for this change came from importing a script served by a CDN that used this content type. 
I faced an error with resolving relative imports:

```
Error: Could not resolve '../../<relative path>' from https://<cdn with js>
```

I tested this patch locally and managed to get rollup working as intended with such URL 🎉 